### PR TITLE
feat: static markup for archive_plugin browse template

### DIFF
--- a/templates/archive_plugin/browse.html
+++ b/templates/archive_plugin/browse.html
@@ -3,24 +3,86 @@
 {% load hooks %}
 {% load i18n %}
 
-
-{% block title %}Browse{% endblock %}
+{% block title %}Table of Contents{% endblock %}
 
 {% block css %}
 {% endblock %}
 
 {% block body %}
-    <section id="content">
-        <div class="row">
-            <div class="large-8 columns border-right">
-                <h3>Browse Entries</h3>
-                {% hook 'journal_archive_list' %}
-                {% for article in articles %}
-                    {% include "elements/journal/box_article.html" with article=article %}
-                {% empty %}
-                    <h3>There are no articles published in this journal yet.</h3>
-                {% endfor %}
-            </div>
+<section id="content">
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-9">
+      <h2 class="cmp-page__title">
+        {% trans "Table of Contents" %}
+      </h2>
+      <div class="cmp-toc">
+        <div class="cmp-toc__group">
+          <h3 class="cmp-toc__title">A</h3>
+          <ul class="cmp-toc__list">
+            <li class="cmp-toc__item">
+              <a class="cmp-toc__link" href="#">A Title &#x2022; Author Name</a>
+            </li>
+            <li class="cmp-toc__item">
+              <a class="cmp-toc__link" href="#">A Very Long Title That Will Just Keep On Growing Adipiscing interdum penatibus fusce facilisis arcu etiam nullam auctor tortor augue blandit nam vulputate amet orci
+              dignissim dolor class ornare feugiat magna mi nunc phasellus eros faucibus tincidunt aliquet elit &#x2022; Author Name</a>
+            </li>
+            <li class="cmp-toc__item">
+              <a class="cmp-toc__link" href="#">A Title &#x2022; Author Name</a>
+            </li>
+            <li class="cmp-toc__item">
+              <a class="cmp-toc__link" href="#">A Title &#x2022; Author Name</a>
+            </li>
+            <li class="cmp-toc__item">
+              <a class="cmp-toc__link" href="#">A Title &#x2022; Author Name</a>
+            </li>
+            <li class="cmp-toc__item">
+              <a class="cmp-toc__link" href="#">A Title &#x2022; Author Name</a>
+            </li>
+          </ul>
         </div>
-    </section>
+        <div class="cmp-toc__group">
+          <h3 class="cmp-toc__title">B</h3>
+          <ul>
+            <li class="cmp-toc__item">
+              <a class="cmp-toc__link" href="#">B Title &#x2022; Author Name</a>
+            </li>
+            <li class="cmp-toc__item">
+              <a class="cmp-toc__link" href="#">B Title &#x2022; Author Name</a>
+            </li>
+            <li class="cmp-toc__item">
+              <a class="cmp-toc__link" href="#">B Title &#x2022; Author Name</a>
+            </li>
+            <li class="cmp-toc__item">
+              <a class="cmp-toc__link" href="#">B Title &#x2022; Author Name</a>
+            </li>
+            <li class="cmp-toc__item">
+              <a class="cmp-toc__link" href="#">B Title &#x2022; Author Name</a>
+            </li>
+            <li class="cmp-toc__item">
+              <a class="cmp-toc__link" href="#">B Title &#x2022; Author Name</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <aside class="cell large-3">
+      <ul class="cmp-secondary-nav__list">
+        <li class="cmp-secondary-nav__item">
+          <a class="cmp-secondary-nav__link" href="#">Encyclopedia Archives</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+{% comment %}
+  old code from this template.
+  {% hook 'journal_archive_list' %}
+  {% for article in articles %}
+  {% include "elements/journal/box_article.html" with article=article %}
+  {% empty %}
+  <h3>There are no articles published in this journal yet.</h3>
+  {% endfor %}
+{% endcomment %}
+
 {% endblock %}

--- a/templates/archive_plugin/browse.html
+++ b/templates/archive_plugin/browse.html
@@ -66,11 +66,7 @@
       </div>
     </div>
     <aside class="cell large-3">
-      <ul class="cmp-secondary-nav__list">
-        <li class="cmp-secondary-nav__item">
-          <a class="cmp-secondary-nav__link" href="#">Encyclopedia Archives</a>
-        </li>
-      </ul>
+      {% hook 'journal_archive_list' %}
     </div>
   </div>
 </section>

--- a/templates/archive_plugin/inject_journal_archive.html
+++ b/templates/archive_plugin/inject_journal_archive.html
@@ -1,3 +1,5 @@
-<div>
-    <h5><a href="{% url 'journal_issues' %}">Encyclopedia Archives</a></h5>
-</div>
+<ul class="cmp-secondary-nav__list">
+  <li class="cmp-secondary-nav__item">
+    <a class="cmp-secondary-nav__link" href="{% url 'journal_issues' %}">Encyclopedia Archives</a>
+  </li>
+</ul>


### PR DESCRIPTION
This writes HTML for the archive_plugin's "browses" template. Currently, this is "static" and is meant to serve as a base for how the markup should be rendered when the plugin fetches its results and displays them in alphabetic order.

@hachacha @mdlincoln: I've commented out the code that was in here previously, as it looks like it was meant to loop over and display results according to the `elements/journal/box_article.html` template. We'll need to wire up this template to display the results as suggested in the mockup. I'm happy to take care of that, but I don't have the experience of having done that in Python/Django.

## Screenshot of how actual results should render:

![localhost_8000_cmesh_plugins_archive_plugin_browse_entries_](https://user-images.githubusercontent.com/360251/53288859-06ac8800-375c-11e9-964a-5fa4cc5dfe6e.png)