### PR TITLE
Document version types

### DIFF
--- a/models.py
+++ b/models.py
@@ -10,6 +10,11 @@ UPDATE_CHOICES = [
     (UPDATE_TYPE_MAJOR, 'Major')
 ]
 
+UPDATE_INFO = {
+    UPDATE_TYPE_MINOR: 'Correction of a typographical error',
+    UPDATE_TYPE_MAJOR: 'Substantive content change, including new bibliographic entries'
+}
+
 
 class Version(models.Model):
     article = models.OneToOneField(Article, null=True, on_delete=models.SET_NULL)
@@ -21,3 +26,7 @@ class Version(models.Model):
     is_archived = models.BooleanField(default=False)
 
     # can tell if version is published by accessing version's article.stage attribute
+
+    @property
+    def update_type_info(self):
+        return UPDATE_INFO[self.update_type]

--- a/templates/archive_plugin/article_version_list.html
+++ b/templates/archive_plugin/article_version_list.html
@@ -19,7 +19,7 @@
             <h4>Version History</h4>
             <ul>
                 {% for version in versions %}
-                    <li><a href="{% url 'article_view' version.identifier.id_type version.identifier.identifier %}">{% if version == orig_article %}<strong>>> {% endif %}{{ version.date_published | date:"F d, Y" }}{% if version == orig_article %}</strong>{% endif %}</a>{% if version.version %}: {{ version.version.update_type }} update{% if not version.version.is_archived %}, <strong>NOT ARCHIVED</strong>{% endif %}
+                    <li><a href="{% url 'article_view' version.identifier.id_type version.identifier.identifier %}">{% if version == orig_article %}<strong>>> {% endif %}{{ version.date_published | date:"F d, Y" }}{% if version == orig_article %}</strong>{% endif %}</a>{% if version.version %}: <span data-tooltip aria-haspopup="true" class="has-tip" title="{{ version.version.update_type_info }}">{{ version.version.update_type }} update</span>{% if not version.version.is_archived %}, <strong>NOT ARCHIVED</strong>{% endif %}
                         {% else %}: original entry{% if not version.issues.exists %}, <strong>NOT ARCHIVED</strong>{% endif %}{% endif %}</li>
                 {% endfor %}
             </ul>


### PR DESCRIPTION
Closes https://github.com/dSHARP-CMU/cmesh-dev/issues/148

This adds a longer description for each version type, and exposes that info as a tooltip in the article archives list