### PR TITLE
Create archive button

### DIFF
--- a/templates/archive_plugin/index.html
+++ b/templates/archive_plugin/index.html
@@ -14,6 +14,7 @@
                         {{ admin_form|foundation }}
                         <button class="button success" type="submit">Save Settings</button>
                     </form>
+                    <a class="button" title="Create a new archvie containing all the most recently published versions of articles."  aria-haspopup="true" data-fade-out-duration="1000" aria-describedby="pyltep-tooltip" data-yeti-box="pyltep-tooltip" data-toggle="pyltep-tooltip" data-resize="pyltep-tooltip" data-events="resize" href="{% url 'create_archive' %}">Create a new journal archive</a>
                 </div>
             </div>
         </div>

--- a/templates/archive_plugin/index.html
+++ b/templates/archive_plugin/index.html
@@ -14,7 +14,11 @@
                         {{ admin_form|foundation }}
                         <button class="button success" type="submit">Save Settings</button>
                     </form>
-                    <a class="button" title="Create a new archvie containing all the most recently published versions of articles."  aria-haspopup="true" data-fade-out-duration="1000" aria-describedby="pyltep-tooltip" data-yeti-box="pyltep-tooltip" data-toggle="pyltep-tooltip" data-resize="pyltep-tooltip" data-events="resize" href="{% url 'create_archive' %}">Create a new journal archive</a>
+                    <form method="POST" action="{%url 'create_archive' %}">
+                        {% csrf_token %}
+                        <button class="button" title="Create a new archvie containing all the most recently published versions of articles."  aria-haspopup="true" data-fade-out-duration="1000" aria-describedby="pyltep-tooltip" data-yeti-box="pyltep-tooltip" data-toggle="pyltep-tooltip" data-resize="pyltep-tooltip" data-events="resize" type="submit">Create a new journal archive</button>
+                    </form>                    
+                    
                 </div>
             </div>
         </div>

--- a/urls.py
+++ b/urls.py
@@ -9,4 +9,5 @@ urlpatterns = [
     url(r'^article/(?P<article_id>\d+)/update/$', views.update_article, name='update_article'),
     url(r'^article/(?P<article_id>\d+)/request_update/$', views.request_update, name='request_update'),
     url(r'^browse_entries/$', views.browse_entries, name='browse_entries'),
+    url(r'^create_archive/$', views.create_archive, name='create_archive'),
 ]

--- a/views.py
+++ b/views.py
@@ -2,6 +2,7 @@ from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib import messages
 from django.urls import reverse
 from django.db.models import Q
+from django.core.management import call_command
 
 from plugins.archive_plugin import forms, plugin_settings, logic, transactional_emails
 from plugins.archive_plugin.models import Version
@@ -149,9 +150,13 @@ def create_archive(request):
     Creates a new journal archive containing the most up-to-date articles via the management command.
     """
 
-    messages.add_message(request, messages.SUCCESS, "New journal archive created")
-
-    return redirect(reverse('manage_issues'))
+    try:
+        call_command('create_archive')
+    except:
+        messages.add_message(request, messages.ERROR, "Archive creation failed. Contact your system administrator.")
+    else:
+        messages.add_message(request, messages.SUCCESS, "New journal archive created")
+        return redirect(reverse('manage_issues'))
 
 
 def browse_entries(request):

--- a/views.py
+++ b/views.py
@@ -154,6 +154,7 @@ def create_archive(request):
         call_command('create_archive')
     except:
         messages.add_message(request, messages.ERROR, "Archive creation failed. Contact your system administrator.")
+        return redirect(reverse('archive_index'))
     else:
         messages.add_message(request, messages.SUCCESS, "New journal archive created")
         return redirect(reverse('manage_issues'))

--- a/views.py
+++ b/views.py
@@ -19,7 +19,7 @@ def index(request):
     Creates the admin page for turning the plugin's elements on or off
     """
     plugin = models.Plugin.objects.get(name=plugin_settings.SHORT_NAME)
-    
+
     journal_archive_enabled = setting_handler.get_plugin_setting(plugin, 'journal_archive_enabled', request.journal, create=True,
                                                         pretty='Enable Journal Archive Display', types='boolean').processed_value
     article_archive_enabled = setting_handler.get_plugin_setting(plugin, 'article_archive_enabled', request.journal, create=True,
@@ -28,8 +28,8 @@ def index(request):
                                                         pretty='Enable Article Editing and Updating', types='boolean').processed_value
     request_template = setting_handler.get_plugin_setting(plugin, 'request_email_template', request.journal, create=True,
                                                         pretty='Request Email Template', types='rich-text').processed_value
-    
-    admin_form = forms.ArchiveAdminForm(initial={'journal_archive_enabled': journal_archive_enabled, 
+
+    admin_form = forms.ArchiveAdminForm(initial={'journal_archive_enabled': journal_archive_enabled,
                                                 'article_archive_enabled': article_archive_enabled,
                                                 'edit_article_enabled': edit_article_enabled,
                                                 'request_email_template': request_template})
@@ -83,7 +83,7 @@ def article_archive(request, article_id):
         versions = Article.objects.filter(Q(version__base_article=base_article) | Q(pk=base_article.pk)).filter(stage='Published').order_by('-date_published')
 
         # prepare and return page
-        
+
         context = {'base_article': base_article, 'orig_article': article, 'versions': versions, 'journal': request.journal}
 
     # if no updates, just return the single entry
@@ -101,10 +101,10 @@ def update_article_prompt(request, article_id):
     : article_id is the pk of the article
     """
     article = get_object_or_404(Article, pk=article_id)
-    
+
     template = 'archive_plugin/inject_edit_article_selector.html'
     context = {'article': article}
-    
+
     return render(request, template, context)
 
 
@@ -134,13 +134,24 @@ def request_update(request, article_id):
     Processes request from editor to have an entry updated, sends email to registered article owner with update request.
     article_id is pk of the article to be updated
     """
-    
+
     article = get_object_or_404(Article, pk=article_id)
     transactional_emails.send_update_request_email(request, article)
 
     messages.add_message(request, messages.SUCCESS, "Email request sent.")
 
     return redirect(reverse('manage_archive_article', kwargs={'article_id': article.pk}))
+
+
+@editor_user_required
+def create_archive(request):
+    """
+    Creates a new journal archive containing the most up-to-date articles via the management command.
+    """
+
+    messages.add_message(request, messages.SUCCESS, "New journal archive created")
+
+    return redirect(reverse('manage_issues'))
 
 
 def browse_entries(request):


### PR DESCRIPTION
This adds a button to the archive plugin settings page that allows an editor to call the `create_archive` management command. On successfully running the command, this will redirect the editor to the issue management page where they can see the issue and edit its name/metadata if they wish.

Closes https://github.com/dSHARP-CMU/cmesh-dev/issues/316