### PR TITLE
populate authors, keywords when beginning article revision

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -48,6 +48,11 @@ def copy_article_for_update(article_id):
     for k in original_keywords:
         article.keywords.add(k)
 
+    # Null out article images so that it is possible to upload new ones
+    article.large_image_file = None
+    article.thumbnail_image_file = None
+    article.meta_image = None
+
     # Save and return copied article
     article.save()
     return article


### PR DESCRIPTION
Closes https://github.com/dSHARP-CMU/cmesh-dev/issues/328
Closes https://github.com/dSHARP-CMU/cmesh-dev/issues/334

note that this imports `copy` so that the `original_article` instance is preserved and its m2m relations for `authors`, `articleauthororder_set`, and `keywords` are preserved for copying into the new article